### PR TITLE
Update documentation link for Bevy Sprinkles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Then run it from anywhere with the `sprinkles` command.
 
 ## Documentation
 
-Documentation is available at [docs.rs](https://docs.rs/bevy/latest/bevy_sprinkles).
+Documentation is available at [docs.rs](https://docs.rs/bevy_sprinkles/latest/bevy_sprinkles/).
 
 ## Bevy version table
 


### PR DESCRIPTION
The previous url didn't exist (yet? :D )