### PR TITLE
rename user facing API: ParticleSystem -> Particles

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Spawn a particle system from a RON asset file:
 
 ```rust
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(ParticleSystem3D {
+    commands.spawn(Particles3d {
         handle: asset_server.load("my_effect.ron"),
     });
 }

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -76,9 +76,7 @@ fn spawn_systems(commands: &mut Commands, asset_server: &AssetServer, grid_range
         for y in -grid_range..=grid_range {
             commands.spawn((
                 BenchParticleSystem,
-                Particles3d {
-                    handle: asset_server.load("3d-explosion.ron"),
-                },
+                Particles3d(asset_server.load("3d-explosion.ron")),
                 Transform::from_xyz(x as f32 * SPACING, y as f32 * SPACING, 0.0),
             ));
         }

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -76,7 +76,7 @@ fn spawn_systems(commands: &mut Commands, asset_server: &AssetServer, grid_range
         for y in -grid_range..=grid_range {
             commands.spawn((
                 BenchParticleSystem,
-                ParticleSystem3D {
+                Particles3d {
                     handle: asset_server.load("3d-explosion.ron"),
                 },
                 Transform::from_xyz(x as f32 * SPACING, y as f32 * SPACING, 0.0),

--- a/crates/bevy_sprinkles/src/asset/mod.rs
+++ b/crates/bevy_sprinkles/src/asset/mod.rs
@@ -22,14 +22,14 @@ use thiserror::Error;
 use serde_helpers::*;
 use versions::current_format_version;
 
-/// Asset loader for [`ParticleSystemAsset`] files in RON format.
+/// Asset loader for [`ParticlesAsset`] files in RON format.
 #[derive(Default, TypePath)]
-pub struct ParticleSystemAssetLoader;
+pub struct ParticlesAssetLoader;
 
-/// Errors that can occur when loading a [`ParticleSystemAsset`].
+/// Errors that can occur when loading a [`ParticlesAsset`].
 #[non_exhaustive]
 #[derive(Debug, Error)]
-pub enum ParticleSystemAssetLoaderError {
+pub enum ParticlesAssetLoaderError {
     /// An I/O error occurred while reading the asset file.
     #[error("Could not load asset: {0}")]
     Io(#[from] std::io::Error),
@@ -38,10 +38,10 @@ pub enum ParticleSystemAssetLoaderError {
     Migration(#[from] versions::MigrationError),
 }
 
-impl AssetLoader for ParticleSystemAssetLoader {
-    type Asset = ParticleSystemAsset;
+impl AssetLoader for ParticlesAssetLoader {
+    type Asset = ParticlesAsset;
     type Settings = ();
-    type Error = ParticleSystemAssetLoaderError;
+    type Error = ParticlesAssetLoaderError;
 
     async fn load(
         &self,
@@ -88,7 +88,7 @@ bitflags! {
 
 /// Whether the particle system operates in 3D or 2D space.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, Reflect)]
-pub enum ParticleSystemDimension {
+pub enum ParticlesDimension {
     /// 3D particle system.
     #[default]
     D3,
@@ -1185,7 +1185,7 @@ pub enum SubEmitterMode {
 pub struct SubEmitterConfig {
     /// When the sub-emitter triggers.
     pub mode: SubEmitterMode,
-    /// Index of the target emitter (within the same [`ParticleSystemAsset`]) to spawn from.
+    /// Index of the target emitter (within the same [`ParticlesAsset`]) to spawn from.
     pub target_emitter: usize,
     /// How often particles are emitted from the sub-emitter, in seconds.
     ///
@@ -1363,15 +1363,15 @@ impl ParticleSystemAuthors {
 /// A complete particle system asset, loadable from RON files.
 ///
 /// Contains one or more emitters and optional colliders that together define a
-/// particle effect. Load this asset and reference it from a [`ParticleSystem3D`](crate::ParticleSystem3D)
-/// or [`ParticleSystem2D`](crate::ParticleSystem2D) component to render the effect.
+/// particle effect. Load this asset and reference it from a [`Particles3d`](crate::Particles3d)
+/// or [`Particles2d`](crate::Particles2d) component to render the effect.
 #[derive(Asset, Debug, Clone, Serialize, Deserialize, Reflect)]
-pub struct ParticleSystemAsset {
+pub struct ParticlesAsset {
     sprinkles_version: String,
     /// Display name for this particle system.
     pub name: String,
     /// Whether this is a 3D or 2D particle system.
-    pub dimension: ParticleSystemDimension,
+    pub dimension: ParticlesDimension,
     /// Initial transform applied when spawning this particle system.
     ///
     /// Only used during spawning if no [`Transform`] is already present on the entity.
@@ -1396,11 +1396,11 @@ pub struct ParticleSystemAsset {
     pub sprinkles_editor: SprinklesEditorData,
 }
 
-impl ParticleSystemAsset {
+impl ParticlesAsset {
     /// Creates a new particle system asset with the current format version.
     pub fn new(
         name: String,
-        dimension: ParticleSystemDimension,
+        dimension: ParticlesDimension,
         initial_transform: InitialTransform,
         emitters: Vec<EmitterData>,
         colliders: Vec<ColliderData>,

--- a/crates/bevy_sprinkles/src/asset/mod.rs
+++ b/crates/bevy_sprinkles/src/asset/mod.rs
@@ -1344,7 +1344,7 @@ impl SprinklesEditorData {
 
 /// Attribution information for a particle system.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Reflect)]
-pub struct ParticleSystemAuthors {
+pub struct ParticlesAuthors {
     /// The original creator this effect was inspired by.
     #[serde(default, skip_serializing_if = "is_empty_string")]
     pub inspired_by: String,
@@ -1353,7 +1353,7 @@ pub struct ParticleSystemAuthors {
     pub submitted_by: String,
 }
 
-impl ParticleSystemAuthors {
+impl ParticlesAuthors {
     /// Returns `true` if both fields are empty
     pub fn is_empty(&self) -> bool {
         self.inspired_by.is_empty() && self.submitted_by.is_empty()
@@ -1389,8 +1389,8 @@ pub struct ParticlesAsset {
     #[serde(default, skip_serializing_if = "is_false")]
     pub despawn_on_finish: bool,
     /// Attribution information.
-    #[serde(default, skip_serializing_if = "ParticleSystemAuthors::is_empty")]
-    pub authors: ParticleSystemAuthors,
+    #[serde(default, skip_serializing_if = "ParticlesAuthors::is_empty")]
+    pub authors: ParticlesAuthors,
     /// Editor-specific metadata.
     #[serde(default, skip_serializing_if = "SprinklesEditorData::is_empty")]
     pub sprinkles_editor: SprinklesEditorData,
@@ -1405,7 +1405,7 @@ impl ParticlesAsset {
         emitters: Vec<EmitterData>,
         colliders: Vec<ColliderData>,
         despawn_on_finish: bool,
-        authors: ParticleSystemAuthors,
+        authors: ParticlesAuthors,
     ) -> Self {
         Self {
             sprinkles_version: current_format_version().to_string(),

--- a/crates/bevy_sprinkles/src/asset/versions/mod.rs
+++ b/crates/bevy_sprinkles/src/asset/versions/mod.rs
@@ -3,7 +3,7 @@ mod v0_1;
 use serde::Deserialize;
 use thiserror::Error;
 
-use super::ParticleSystemAsset;
+use super::ParticlesAsset;
 
 const CURRENT_FORMAT_VERSION: &str = "0.2";
 
@@ -31,7 +31,7 @@ pub enum MigrationError {
 /// The result of a [`migrate`] call.
 pub struct MigrationResult {
     /// The particle system asset in the current format version.
-    pub asset: ParticleSystemAsset,
+    pub asset: ParticlesAsset,
     /// Whether the asset was migrated from an older version.
     pub was_migrated: bool,
 }
@@ -43,15 +43,15 @@ pub fn migrate(bytes: &[u8]) -> Result<MigrationResult, MigrationError> {
 
     match probe.sprinkles_version.as_str() {
         v if v == current => {
-            let asset: ParticleSystemAsset = ron::de::from_bytes(bytes)?;
+            let asset: ParticlesAsset = ron::de::from_bytes(bytes)?;
             Ok(MigrationResult {
                 asset,
                 was_migrated: false,
             })
         }
         "0.1" => {
-            let old: v0_1::ParticleSystemAsset = ron::de::from_bytes(bytes)?;
-            let asset: ParticleSystemAsset = old.into();
+            let old: v0_1::ParticlesAsset = ron::de::from_bytes(bytes)?;
+            let asset: ParticlesAsset = old.into();
             Ok(MigrationResult {
                 asset,
                 was_migrated: true,

--- a/crates/bevy_sprinkles/src/asset/versions/v0_1.rs
+++ b/crates/bevy_sprinkles/src/asset/versions/v0_1.rs
@@ -9,9 +9,9 @@ use super::super::{
     EmitterEmission, EmitterScale as CurrentEmitterScale, EmitterTime,
     EmitterTrail as CurrentEmitterTrail, EmitterTurbulence as CurrentEmitterTurbulence,
     EmitterVelocities as CurrentEmitterVelocities, Gradient, InitialTransform, ParticleFlags,
-    ParticleSystemAsset as CurrentParticleSystemAsset,
-    ParticleSystemAuthors as CurrentParticleSystemAuthors, ParticleSystemDimension,
-    ParticlesColliderShape3D, Range, SolidOrGradientColor, SprinklesEditorData, SubEmitterConfig,
+    ParticleSystemAuthors as CurrentParticleSystemAuthors, ParticlesAsset as CurrentParticlesAsset,
+    ParticlesColliderShape3D, ParticlesDimension, Range, SolidOrGradientColor, SprinklesEditorData,
+    SubEmitterConfig,
 };
 
 #[derive(Debug, Clone, Deserialize)]
@@ -59,11 +59,11 @@ impl From<ParticleSystemAuthors> for CurrentParticleSystemAuthors {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub(super) struct ParticleSystemAsset {
+pub(super) struct ParticlesAsset {
     #[allow(dead_code)]
     sprinkles_version: String,
     name: String,
-    dimension: ParticleSystemDimension,
+    dimension: ParticlesDimension,
     #[serde(default)]
     initial_transform: InitialTransform,
     emitters: Vec<EmitterData>,
@@ -400,10 +400,10 @@ pub(super) struct ColliderData {
     position: Vec3,
 }
 
-impl From<ParticleSystemAsset> for CurrentParticleSystemAsset {
-    fn from(old: ParticleSystemAsset) -> Self {
+impl From<ParticlesAsset> for CurrentParticlesAsset {
+    fn from(old: ParticlesAsset) -> Self {
         let authors = old.authors.map(Into::into).unwrap_or_default();
-        let mut asset = CurrentParticleSystemAsset::new(
+        let mut asset = CurrentParticlesAsset::new(
             old.name,
             old.dimension,
             old.initial_transform,

--- a/crates/bevy_sprinkles/src/asset/versions/v0_1.rs
+++ b/crates/bevy_sprinkles/src/asset/versions/v0_1.rs
@@ -9,7 +9,7 @@ use super::super::{
     EmitterEmission, EmitterScale as CurrentEmitterScale, EmitterTime,
     EmitterTrail as CurrentEmitterTrail, EmitterTurbulence as CurrentEmitterTurbulence,
     EmitterVelocities as CurrentEmitterVelocities, Gradient, InitialTransform, ParticleFlags,
-    ParticleSystemAuthors as CurrentParticleSystemAuthors, ParticlesAsset as CurrentParticlesAsset,
+    ParticlesAsset as CurrentParticlesAsset, ParticlesAuthors as CurrentParticleSystemAuthors,
     ParticlesColliderShape3D, ParticlesDimension, Range, SolidOrGradientColor, SprinklesEditorData,
     SubEmitterConfig,
 };
@@ -43,14 +43,14 @@ fn migrate_curve(old: Option<OldCurveTexture>) -> Option<CurveTexture> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct ParticleSystemAuthors {
+struct ParticlesAuthors {
     #[serde(default)]
     inspired_by: Option<String>,
     submitted_by: String,
 }
 
-impl From<ParticleSystemAuthors> for CurrentParticleSystemAuthors {
-    fn from(old: ParticleSystemAuthors) -> Self {
+impl From<ParticlesAuthors> for CurrentParticleSystemAuthors {
+    fn from(old: ParticlesAuthors) -> Self {
         Self {
             inspired_by: old.inspired_by.unwrap_or_default(),
             submitted_by: old.submitted_by,
@@ -72,7 +72,7 @@ pub(super) struct ParticlesAsset {
     #[serde(default)]
     despawn_on_finish: bool,
     #[serde(default)]
-    authors: Option<ParticleSystemAuthors>,
+    authors: Option<ParticlesAuthors>,
     #[serde(default)]
     sprinkles_editor: SprinklesEditorData,
 }

--- a/crates/bevy_sprinkles/src/extract.rs
+++ b/crates/bevy_sprinkles/src/extract.rs
@@ -591,7 +591,7 @@ pub fn extract_particle_systems(
         let Ok((particle_system, _)) = system_query.get(emitter_entity.parent_system) else {
             continue;
         };
-        let Some(asset) = assets.get(&particle_system.handle) else {
+        let Some(asset) = assets.get(particle_system) else {
             continue;
         };
         let Some(emitter) = asset.emitters.get(runtime.emitter_index) else {
@@ -614,7 +614,7 @@ pub fn extract_particle_systems(
             continue;
         };
 
-        let Some(asset) = assets.get(&particle_system.handle) else {
+        let Some(asset) = assets.get(particle_system) else {
             continue;
         };
 

--- a/crates/bevy_sprinkles/src/extract.rs
+++ b/crates/bevy_sprinkles/src/extract.rs
@@ -7,13 +7,12 @@ use bytemuck::{Pod, Zeroable};
 use crate::{
     asset::{
         AnimatedVelocity, CurveTexture, DrawOrder, EmissionShape, EmitterCollisionMode,
-        EmitterData, ParticleFlags, ParticleSystemAsset, ParticlesColliderShape3D,
-        SolidOrGradientColor, SubEmitterMode,
+        EmitterData, ParticleFlags, ParticlesAsset, ParticlesColliderShape3D, SolidOrGradientColor,
+        SubEmitterMode,
     },
     runtime::{
-        EmitterEntity, EmitterRuntime, ParticleBufferHandle, ParticleSystem3D,
-        ParticleSystemRuntime, ParticlesCollider3D, SubEmitterBufferHandle, compute_phase,
-        is_past_delay,
+        EmitterEntity, EmitterRuntime, ParticleBufferHandle, ParticleSystemRuntime, Particles3d,
+        ParticlesCollider3D, SubEmitterBufferHandle, compute_phase, is_past_delay,
     },
     textures::{CurveTextureCache, GradientTextureCache},
 };
@@ -565,9 +564,9 @@ pub fn extract_particle_systems(
             Option<&SubEmitterBufferHandle>,
         )>,
     >,
-    system_query: Extract<Query<(&ParticleSystem3D, &ParticleSystemRuntime)>>,
+    system_query: Extract<Query<(&Particles3d, &ParticleSystemRuntime)>>,
     camera_query: Extract<Query<&GlobalTransform, With<Camera3d>>>,
-    assets: Extract<Res<Assets<ParticleSystemAsset>>>,
+    assets: Extract<Res<Assets<ParticlesAsset>>>,
     gradient_cache: Extract<Res<GradientTextureCache>>,
     curve_cache: Extract<Res<CurveTextureCache>>,
 ) {

--- a/crates/bevy_sprinkles/src/lib.rs
+++ b/crates/bevy_sprinkles/src/lib.rs
@@ -49,9 +49,7 @@
 //! use bevy_sprinkles::prelude::*;
 //!
 //! fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-//!     commands.spawn(Particles3d {
-//!         handle: asset_server.load("my_effect.ron"),
-//!     });
+//!     commands.spawn(Particles3d(asset_server.load("my_effect.ron")));
 //! }
 //! ```
 //!
@@ -85,7 +83,7 @@
 //!         Default::default(),
 //!     ));
 //!
-//!     commands.spawn(Particles3d { handle });
+//!     commands.spawn(Particles3d(handle));
 //! }
 //! ```
 //!

--- a/crates/bevy_sprinkles/src/lib.rs
+++ b/crates/bevy_sprinkles/src/lib.rs
@@ -37,8 +37,8 @@
 //!
 //! ## Spawning a particle system
 //!
-//! A particle system is defined by a [`ParticleSystemAsset`] containing one or more
-//! [`EmitterData`] entries. Spawn a [`ParticleSystem3D`] component to render the effect.
+//! A particle system is defined by a [`ParticlesAsset`] containing one or more
+//! [`EmitterData`] entries. Spawn a [`Particles3d`] component to render the effect.
 //!
 //! ### Loading from a file
 //!
@@ -49,7 +49,7 @@
 //! use bevy_sprinkles::prelude::*;
 //!
 //! fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-//!     commands.spawn(ParticleSystem3D {
+//!     commands.spawn(Particles3d {
 //!         handle: asset_server.load("my_effect.ron"),
 //!     });
 //! }
@@ -57,16 +57,16 @@
 //!
 //! ### Building in code
 //!
-//! You can also build a [`ParticleSystemAsset`] directly:
+//! You can also build a [`ParticlesAsset`] directly:
 //!
 //! ```
 //! use bevy::prelude::*;
 //! use bevy_sprinkles::prelude::*;
 //!
-//! fn setup(mut commands: Commands, mut assets: ResMut<Assets<ParticleSystemAsset>>) {
-//!     let handle = assets.add(ParticleSystemAsset::new(
+//! fn setup(mut commands: Commands, mut assets: ResMut<Assets<ParticlesAsset>>) {
+//!     let handle = assets.add(ParticlesAsset::new(
 //!         "My Effect".into(),
-//!         ParticleSystemDimension::D3,
+//!         ParticlesDimension::D3,
 //!         Default::default(),
 //!         vec![EmitterData {
 //!             emission: EmitterEmission {
@@ -85,7 +85,7 @@
 //!         Default::default(),
 //!     ));
 //!
-//!     commands.spawn(ParticleSystem3D { handle });
+//!     commands.spawn(Particles3d { handle });
 //! }
 //! ```
 //!
@@ -100,7 +100,7 @@
 //!
 //! A particle system is the top-level container for one or more emitters and optional colliders.
 //!
-//! - [Spawning a system](ParticleSystem3D) with a handle to a [`ParticleSystemAsset`]
+//! - [Spawning a system](Particles3d) with a handle to a [`ParticlesAsset`]
 //! - [Playback control](ParticleSystemRuntime) (pause, resume, restart)
 //! - [Per-emitter runtime state](EmitterRuntime)
 //!
@@ -182,7 +182,7 @@ use bevy::{
 
 const SHADER_COMMON: Handle<Shader> = uuid_handle!("10b6a301-2396-4ce0-906a-b3e38aaddddf");
 
-use asset::{ParticleSystemAsset, ParticleSystemAssetLoader};
+use asset::{ParticlesAsset, ParticlesAssetLoader};
 use compute::ParticleComputePlugin;
 use extract::{extract_colliders, extract_particle_systems};
 use mesh::ParticleMeshCache;
@@ -214,8 +214,8 @@ impl Plugin for SprinklesPlugin {
         #[cfg(feature = "preset-textures")]
         textures::preset::register_preset_textures(app);
 
-        app.init_asset::<ParticleSystemAsset>()
-            .init_asset_loader::<ParticleSystemAssetLoader>();
+        app.init_asset::<ParticlesAsset>()
+            .init_asset_loader::<ParticlesAssetLoader>();
 
         app.init_resource::<GradientTextureCache>()
             .add_systems(Startup, create_fallback_gradient_texture)
@@ -265,14 +265,14 @@ pub use asset::{
     ColliderData, DrawOrder, DrawPassMaterial, EmitterAccelerations, EmitterCollision,
     EmitterCollisionMode, EmitterColors, EmitterData, EmitterDrawPass, EmitterEmission,
     EmitterScale, EmitterTime, EmitterTrail, EmitterTurbulence, EmitterVelocities, ParticleFlags,
-    ParticleMesh, ParticleSystemDimension, ParticlesColliderShape3D, QuadOrientation,
-    RibbonTrailShape, SerializableAlphaMode, StandardParticleMaterial, TransformAlign,
+    ParticleMesh, ParticlesColliderShape3D, ParticlesDimension, QuadOrientation, RibbonTrailShape,
+    SerializableAlphaMode, StandardParticleMaterial, TransformAlign,
 };
 pub use material::ParticleMaterialExtension;
 pub use runtime::{
     ColliderEntity, EmitterEntity, EmitterRuntime, Finished, ParticleBufferHandle, ParticleData,
-    ParticleMaterial, ParticleMaterialHandle, ParticleSystem2D, ParticleSystem3D,
-    ParticleSystemRuntime, ParticlesCollider3D,
+    ParticleMaterial, ParticleMaterialHandle, ParticleSystemRuntime, Particles2d, Particles3d,
+    ParticlesCollider3D,
 };
 #[cfg(feature = "preset-textures")]
 pub use textures::preset::PresetTexture;

--- a/crates/bevy_sprinkles/src/prelude.rs
+++ b/crates/bevy_sprinkles/src/prelude.rs
@@ -6,11 +6,10 @@ pub use crate::asset::{
     EmitterCollisionMode, EmitterColors, EmitterData, EmitterDrawPass, EmitterEmission,
     EmitterScale, EmitterTime, EmitterTrail, EmitterTurbulence, EmitterVelocities,
     Gradient as ParticleGradient, GradientInterpolation, GradientStop, InitialTransform,
-    ParticleFlags, ParticleMesh, ParticleSystemAsset, ParticleSystemAuthors,
-    ParticleSystemDimension, ParticlesColliderShape3D, QuadOrientation, Range as ParticleRange,
-    RibbonTrailShape, SerializableAlphaMode, SerializableFace, SolidOrGradientColor,
-    SprinklesEditorData, StandardParticleMaterial, SubEmitterConfig, SubEmitterMode,
-    TransformAlign,
+    ParticleFlags, ParticleMesh, ParticleSystemAuthors, ParticlesAsset, ParticlesColliderShape3D,
+    ParticlesDimension, QuadOrientation, Range as ParticleRange, RibbonTrailShape,
+    SerializableAlphaMode, SerializableFace, SolidOrGradientColor, SprinklesEditorData,
+    StandardParticleMaterial, SubEmitterConfig, SubEmitterMode, TransformAlign,
 };
 #[cfg(feature = "preset-textures")]
 pub use crate::textures::preset::PresetTexture;
@@ -18,6 +17,6 @@ pub use crate::textures::preset::TextureRef;
 
 pub use crate::runtime::{
     ColliderEntity, EditorMode, EmitterEntity, EmitterRuntime, Finished, ParticleMaterial,
-    ParticleMaterialHandle, ParticleSystem2D, ParticleSystem3D, ParticleSystemRuntime,
-    ParticlesCollider3D, SubEmitterBufferHandle,
+    ParticleMaterialHandle, ParticleSystemRuntime, Particles2d, Particles3d, ParticlesCollider3D,
+    SubEmitterBufferHandle,
 };

--- a/crates/bevy_sprinkles/src/prelude.rs
+++ b/crates/bevy_sprinkles/src/prelude.rs
@@ -6,7 +6,7 @@ pub use crate::asset::{
     EmitterCollisionMode, EmitterColors, EmitterData, EmitterDrawPass, EmitterEmission,
     EmitterScale, EmitterTime, EmitterTrail, EmitterTurbulence, EmitterVelocities,
     Gradient as ParticleGradient, GradientInterpolation, GradientStop, InitialTransform,
-    ParticleFlags, ParticleMesh, ParticleSystemAuthors, ParticlesAsset, ParticlesColliderShape3D,
+    ParticleFlags, ParticleMesh, ParticlesAsset, ParticlesAuthors, ParticlesColliderShape3D,
     ParticlesDimension, QuadOrientation, Range as ParticleRange, RibbonTrailShape,
     SerializableAlphaMode, SerializableFace, SolidOrGradientColor, SprinklesEditorData,
     StandardParticleMaterial, SubEmitterConfig, SubEmitterMode, TransformAlign,

--- a/crates/bevy_sprinkles/src/runtime.rs
+++ b/crates/bevy_sprinkles/src/runtime.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use bevy::asset::AsAssetId;
 use bevy::pbr::ExtendedMaterial;
 use bevy::prelude::*;
 use bevy::render::render_resource::{Buffer, ShaderType};
@@ -18,21 +19,54 @@ pub(crate) struct TrailHistoryEntry {
 
 /// Component that spawns a 2D particle system from a [`ParticlesAsset`].
 ///
+/// Holds a handle to the particle system asset that defines this effect.
+///
 /// # TODO
 ///
 /// 2D particle systems are not yet implemented. This component exists as a
 /// placeholder; spawning it will have no effect. Use [`Particles3d`] instead.
-#[derive(Component)]
-pub struct Particles2d {
-    /// Handle to the particle system asset that defines this effect.
-    pub handle: Handle<ParticlesAsset>,
+#[derive(Component, Deref, DerefMut)]
+pub struct Particles2d(pub Handle<ParticlesAsset>);
+
+impl From<Particles2d> for AssetId<ParticlesAsset> {
+    fn from(particles: Particles2d) -> Self {
+        particles.id()
+    }
+}
+impl From<&Particles2d> for AssetId<ParticlesAsset> {
+    fn from(particles: &Particles2d) -> Self {
+        particles.id()
+    }
+}
+impl AsAssetId for Particles2d {
+    type Asset = ParticlesAsset;
+
+    fn as_asset_id(&self) -> AssetId<Self::Asset> {
+        self.id()
+    }
 }
 
 /// Component that spawns a 3D particle system from a [`ParticlesAsset`].
-#[derive(Component)]
-pub struct Particles3d {
-    /// Handle to the particle system asset that defines this effect.
-    pub handle: Handle<ParticlesAsset>,
+/// Holds a handle to the particle system asset that defines this effect.
+#[derive(Component, Deref, DerefMut)]
+pub struct Particles3d(pub Handle<ParticlesAsset>);
+
+impl From<Particles3d> for AssetId<ParticlesAsset> {
+    fn from(mesh: Particles3d) -> Self {
+        mesh.id()
+    }
+}
+impl From<&Particles3d> for AssetId<ParticlesAsset> {
+    fn from(mesh: &Particles3d) -> Self {
+        mesh.id()
+    }
+}
+impl AsAssetId for Particles3d {
+    type Asset = ParticlesAsset;
+
+    fn as_asset_id(&self) -> AssetId<Self::Asset> {
+        self.id()
+    }
 }
 
 /// GPU-side per-particle data, packed into `[f32; 4]` vectors for shader alignment.
@@ -417,7 +451,7 @@ pub(crate) fn check_particle_system_finished(
     }
 
     for (system_entity, particle_system, mut system_runtime) in system_query.iter_mut() {
-        let Some(asset) = assets.get(&particle_system.handle) else {
+        let Some(asset) = assets.get(particle_system) else {
             continue;
         };
 

--- a/crates/bevy_sprinkles/src/runtime.rs
+++ b/crates/bevy_sprinkles/src/runtime.rs
@@ -6,7 +6,7 @@ use bevy::render::render_resource::{Buffer, ShaderType};
 use bevy::render::storage::ShaderStorageBuffer;
 use bytemuck::{Pod, Zeroable};
 
-use crate::asset::{DrawPassMaterial, ParticleMesh, ParticleSystemAsset, ParticlesColliderShape3D};
+use crate::asset::{DrawPassMaterial, ParticleMesh, ParticlesAsset, ParticlesColliderShape3D};
 use crate::material::ParticleMaterialExtension;
 
 #[derive(Clone, Copy, Default, Pod, Zeroable, ShaderType)]
@@ -16,23 +16,23 @@ pub(crate) struct TrailHistoryEntry {
     pub(crate) velocity: [f32; 4],
 }
 
-/// Component that spawns a 2D particle system from a [`ParticleSystemAsset`].
+/// Component that spawns a 2D particle system from a [`ParticlesAsset`].
 ///
 /// # TODO
 ///
 /// 2D particle systems are not yet implemented. This component exists as a
-/// placeholder; spawning it will have no effect. Use [`ParticleSystem3D`] instead.
+/// placeholder; spawning it will have no effect. Use [`Particles3d`] instead.
 #[derive(Component)]
-pub struct ParticleSystem2D {
+pub struct Particles2d {
     /// Handle to the particle system asset that defines this effect.
-    pub handle: Handle<ParticleSystemAsset>,
+    pub handle: Handle<ParticlesAsset>,
 }
 
-/// Component that spawns a 3D particle system from a [`ParticleSystemAsset`].
+/// Component that spawns a 3D particle system from a [`ParticlesAsset`].
 #[derive(Component)]
-pub struct ParticleSystem3D {
+pub struct Particles3d {
     /// Handle to the particle system asset that defines this effect.
-    pub handle: Handle<ParticleSystemAsset>,
+    pub handle: Handle<ParticlesAsset>,
 }
 
 /// GPU-side per-particle data, packed into `[f32; 4]` vectors for shader alignment.
@@ -157,7 +157,7 @@ pub struct EmitterRuntime {
     pub inactive_time: f32,
     /// Whether to clear all particles on the next frame.
     pub clear_requested: bool,
-    /// Index of this emitter within the parent [`ParticleSystemAsset::emitters`].
+    /// Index of this emitter within the parent [`ParticlesAsset::emitters`].
     pub emitter_index: usize,
     /// Pending simulation steps to be dispatched to the GPU.
     pub simulation_steps: Vec<SimulationStep>,
@@ -290,16 +290,16 @@ pub fn is_past_delay(time: f32, emitter_time: &crate::asset::EmitterTime) -> boo
 /// Marker component linking an emitter entity back to its parent particle system.
 #[derive(Component)]
 pub struct EmitterEntity {
-    /// The entity that holds the [`ParticleSystem3D`] or [`ParticleSystem2D`] component.
+    /// The entity that holds the [`Particles3d`] or [`Particles2d`] component.
     pub parent_system: Entity,
 }
 
 /// Marker component linking a collider entity back to its parent particle system.
 #[derive(Component)]
 pub struct ColliderEntity {
-    /// The entity that holds the [`ParticleSystem3D`] or [`ParticleSystem2D`] component.
+    /// The entity that holds the [`Particles3d`] or [`Particles2d`] component.
     pub parent_system: Entity,
-    /// Index of this collider within the parent [`ParticleSystemAsset::colliders`].
+    /// Index of this collider within the parent [`ParticlesAsset::colliders`].
     pub collider_index: usize,
 }
 
@@ -399,8 +399,8 @@ impl Default for ParticlesCollider3D {
 
 pub(crate) fn check_particle_system_finished(
     mut commands: Commands,
-    assets: Res<Assets<ParticleSystemAsset>>,
-    mut system_query: Query<(Entity, &ParticleSystem3D, &mut ParticleSystemRuntime)>,
+    assets: Res<Assets<ParticlesAsset>>,
+    mut system_query: Query<(Entity, &Particles3d, &mut ParticleSystemRuntime)>,
     emitter_query: Query<(&EmitterEntity, &EmitterRuntime)>,
 ) {
     let mut system_states: HashMap<Entity, (bool, bool)> = HashMap::new();

--- a/crates/bevy_sprinkles/src/spawning.rs
+++ b/crates/bevy_sprinkles/src/spawning.rs
@@ -3,13 +3,13 @@ use bevy::{
 };
 
 use crate::{
-    asset::{DrawPassMaterial, EmitterData, EmitterTrail, ParticleSystemAsset},
+    asset::{DrawPassMaterial, EmitterData, EmitterTrail, ParticlesAsset},
     material::{ParticleEmitterUniforms, ParticleMaterialExtension, TRAIL_THICKNESS_CURVE_SAMPLES},
     mesh::ParticleMeshCache,
     runtime::{
         ColliderEntity, CurrentMaterialConfig, CurrentMeshConfig, EditorMode, EmitterEntity,
         EmitterRuntime, ParticleBufferHandle, ParticleData, ParticleMaterial,
-        ParticleMaterialHandle, ParticleMeshHandle, ParticleSystem3D, ParticleSystemRuntime,
+        ParticleMaterialHandle, ParticleMeshHandle, ParticleSystemRuntime, Particles3d,
         ParticlesCollider3D, SimulationStep, SubEmitterBufferHandle, TrailHistoryEntry,
     },
 };
@@ -46,9 +46,9 @@ fn compute_trail_history_frames(emitter: &EmitterData) -> u32 {
 
 fn get_particle_asset<'a>(
     parent_system: Entity,
-    particle_systems: &Query<&ParticleSystem3D>,
-    assets: &'a Assets<ParticleSystemAsset>,
-) -> Option<&'a ParticleSystemAsset> {
+    particle_systems: &Query<&Particles3d>,
+    assets: &'a Assets<ParticlesAsset>,
+) -> Option<&'a ParticlesAsset> {
     let particle_system = particle_systems.get(parent_system).ok()?;
     assets.get(&particle_system.handle)
 }
@@ -56,8 +56,8 @@ fn get_particle_asset<'a>(
 fn get_emitter_data<'a>(
     parent_system: Entity,
     emitter_index: usize,
-    particle_systems: &Query<&ParticleSystem3D>,
-    assets: &'a Assets<ParticleSystemAsset>,
+    particle_systems: &Query<&Particles3d>,
+    assets: &'a Assets<ParticlesAsset>,
 ) -> Option<&'a EmitterData> {
     get_particle_asset(parent_system, particle_systems, assets)
         .and_then(|asset| asset.emitters.get(emitter_index))
@@ -66,8 +66,8 @@ fn get_emitter_data<'a>(
 fn get_editor_assets_folders<'a>(
     parent_system: Entity,
     is_editor: bool,
-    particle_systems: &Query<&ParticleSystem3D>,
-    assets: &'a Assets<ParticleSystemAsset>,
+    particle_systems: &Query<&Particles3d>,
+    assets: &'a Assets<ParticlesAsset>,
 ) -> &'a [String] {
     if !is_editor {
         return &[];
@@ -79,8 +79,8 @@ fn get_editor_assets_folders<'a>(
 
 pub fn update_particle_time(
     time: Res<Time>,
-    assets: Res<Assets<ParticleSystemAsset>>,
-    system_query: Query<(&ParticleSystem3D, &ParticleSystemRuntime)>,
+    assets: Res<Assets<ParticlesAsset>>,
+    system_query: Query<(&Particles3d, &ParticleSystemRuntime)>,
     mut emitter_query: Query<(&EmitterEntity, &mut EmitterRuntime)>,
 ) {
     for (emitter, mut runtime) in emitter_query.iter_mut() {
@@ -243,8 +243,8 @@ fn bake_thickness_curve(trail: &EmitterTrail) -> [f32; TRAIL_THICKNESS_CURVE_SAM
 
 pub fn setup_particle_systems(
     mut commands: Commands,
-    query: Query<(Entity, &ParticleSystem3D, Has<EditorMode>), Without<ParticleSystemRuntime>>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    query: Query<(Entity, &Particles3d, Has<EditorMode>), Without<ParticleSystemRuntime>>,
+    assets: Res<Assets<ParticlesAsset>>,
     asset_server: Res<AssetServer>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut mesh_cache: ResMut<ParticleMeshCache>,
@@ -422,7 +422,7 @@ pub fn setup_particle_systems(
 
 pub fn cleanup_particle_entities(
     mut commands: Commands,
-    mut removed_systems: RemovedComponents<ParticleSystem3D>,
+    mut removed_systems: RemovedComponents<Particles3d>,
     emitter_entities: Query<Entity, With<EmitterEntity>>,
     emitter_parent_query: Query<&EmitterEntity>,
     collider_entities: Query<(Entity, &ColliderEntity)>,
@@ -445,8 +445,8 @@ pub fn cleanup_particle_entities(
 }
 
 pub fn sync_collider_data(
-    particle_systems: Query<&ParticleSystem3D>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    particle_systems: Query<&Particles3d>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut collider_query: Query<(&ColliderEntity, &mut ParticlesCollider3D, &mut Transform)>,
 ) {
     if !assets.is_changed() {
@@ -468,7 +468,7 @@ pub fn sync_collider_data(
 }
 
 pub fn sync_particle_mesh(
-    particle_systems: Query<&ParticleSystem3D>,
+    particle_systems: Query<&Particles3d>,
     mut emitter_query: Query<(
         &EmitterEntity,
         &EmitterRuntime,
@@ -477,7 +477,7 @@ pub fn sync_particle_mesh(
         &mut ParticleMeshHandle,
         &mut Mesh3d,
     )>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut mesh_cache: ResMut<ParticleMeshCache>,
 ) {
@@ -506,7 +506,7 @@ pub fn sync_particle_mesh(
 }
 
 pub(crate) fn sync_particle_buffers(
-    particle_systems: Query<&ParticleSystem3D>,
+    particle_systems: Query<&Particles3d>,
     editor_modes: Query<Has<EditorMode>>,
     mut emitter_query: Query<(
         &EmitterEntity,
@@ -519,7 +519,7 @@ pub(crate) fn sync_particle_buffers(
         &mut MeshMaterial3d<ParticleMaterial>,
         &mut CurrentMaterialConfig,
     )>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     asset_server: Res<AssetServer>,
     mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -618,14 +618,14 @@ pub(crate) fn sync_particle_buffers(
 }
 
 pub fn write_emitter_uniforms(
-    particle_systems: Query<&ParticleSystem3D>,
+    particle_systems: Query<&Particles3d>,
     emitter_query: Query<(
         &EmitterEntity,
         &EmitterRuntime,
         &ParticleBufferHandle,
         &GlobalTransform,
     )>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut buffers: ResMut<Assets<ShaderStorageBuffer>>,
 ) {
     for (emitter, runtime, buffer_handle, global_transform) in emitter_query.iter() {
@@ -658,7 +658,7 @@ pub fn write_emitter_uniforms(
 }
 
 pub fn sync_particle_material(
-    particle_systems: Query<&ParticleSystem3D>,
+    particle_systems: Query<&Particles3d>,
     editor_modes: Query<Has<EditorMode>>,
     mut emitter_query: Query<(
         &EmitterEntity,
@@ -667,7 +667,7 @@ pub fn sync_particle_material(
         &mut ParticleMaterialHandle,
         &mut MeshMaterial3d<ParticleMaterial>,
     )>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ParticleMaterial>>,
 ) {

--- a/crates/bevy_sprinkles/src/spawning.rs
+++ b/crates/bevy_sprinkles/src/spawning.rs
@@ -50,7 +50,7 @@ fn get_particle_asset<'a>(
     assets: &'a Assets<ParticlesAsset>,
 ) -> Option<&'a ParticlesAsset> {
     let particle_system = particle_systems.get(parent_system).ok()?;
-    assets.get(&particle_system.handle)
+    assets.get(particle_system)
 }
 
 fn get_emitter_data<'a>(
@@ -88,7 +88,7 @@ pub fn update_particle_time(
             continue;
         };
 
-        let Some(asset) = assets.get(&particle_system.handle) else {
+        let Some(asset) = assets.get(particle_system) else {
             continue;
         };
 
@@ -252,7 +252,7 @@ pub fn setup_particle_systems(
     mut materials: ResMut<Assets<ParticleMaterial>>,
 ) {
     for (system_entity, particle_system, is_editor) in query.iter() {
-        let Some(asset) = assets.get(&particle_system.handle) else {
+        let Some(asset) = assets.get(particle_system) else {
             continue;
         };
 

--- a/crates/bevy_sprinkles/src/textures/baked.rs
+++ b/crates/bevy_sprinkles/src/textures/baked.rs
@@ -140,7 +140,7 @@ pub fn prepare_gradient_textures(
     assets: Res<Assets<ParticlesAsset>>,
 ) {
     for system in &particle_systems {
-        let Some(asset) = assets.get(&system.handle) else {
+        let Some(asset) = assets.get(system) else {
             continue;
         };
         for emitter in &asset.emitters {
@@ -229,7 +229,7 @@ pub fn prepare_curve_textures(
     assets: Res<Assets<ParticlesAsset>>,
 ) {
     for system in &particle_systems {
-        let Some(asset) = assets.get(&system.handle) else {
+        let Some(asset) = assets.get(system) else {
             continue;
         };
         for emitter in &asset.emitters {

--- a/crates/bevy_sprinkles/src/textures/baked.rs
+++ b/crates/bevy_sprinkles/src/textures/baked.rs
@@ -8,9 +8,9 @@ use bevy::{
 use std::collections::HashMap;
 
 use crate::asset::{
-    CurveTexture, Gradient, GradientInterpolation, ParticleSystemAsset, SolidOrGradientColor,
+    CurveTexture, Gradient, GradientInterpolation, ParticlesAsset, SolidOrGradientColor,
 };
-use crate::runtime::ParticleSystem3D;
+use crate::runtime::Particles3d;
 
 const TEXTURE_WIDTH: u32 = 256;
 
@@ -136,8 +136,8 @@ pub struct FallbackGradientTexture {
 pub fn prepare_gradient_textures(
     mut cache: ResMut<GradientTextureCache>,
     mut images: ResMut<Assets<Image>>,
-    particle_systems: Query<&ParticleSystem3D>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    particle_systems: Query<&Particles3d>,
+    assets: Res<Assets<ParticlesAsset>>,
 ) {
     for system in &particle_systems {
         let Some(asset) = assets.get(&system.handle) else {
@@ -225,8 +225,8 @@ impl CurveTextureCache {
 pub fn prepare_curve_textures(
     mut cache: ResMut<CurveTextureCache>,
     mut images: ResMut<Assets<Image>>,
-    particle_systems: Query<&ParticleSystem3D>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    particle_systems: Query<&Particles3d>,
+    assets: Res<Assets<ParticlesAsset>>,
 ) {
     for system in &particle_systems {
         let Some(asset) = assets.get(&system.handle) else {

--- a/crates/bevy_sprinkles/tests/asset_loader.rs
+++ b/crates/bevy_sprinkles/tests/asset_loader.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use thiserror::Error;
 
 use bevy_sprinkles::asset::versions;
-use bevy_sprinkles::asset::{ParticleSystemAsset, ParticleSystemAssetLoader};
+use bevy_sprinkles::asset::{ParticlesAsset, ParticlesAssetLoader};
 
 #[derive(Asset, TypePath, Debug, Serialize, Deserialize, PartialEq)]
 struct DummyData {
@@ -68,8 +68,8 @@ fn create_test_app() -> App {
         ..default()
     });
 
-    app.init_asset::<ParticleSystemAsset>()
-        .init_asset_loader::<ParticleSystemAssetLoader>();
+    app.init_asset::<ParticlesAsset>()
+        .init_asset_loader::<ParticlesAssetLoader>();
 
     app.init_asset::<DummyData>()
         .init_asset_loader::<DummyDataAssetLoader>();
@@ -119,7 +119,7 @@ fn fixture(name: &str) -> String {
 fn test_bevy_loads_valid_ron_particle_system() {
     let mut app = create_test_app();
 
-    let handle: Handle<ParticleSystemAsset> = {
+    let handle: Handle<ParticlesAsset> = {
         let asset_server = app.world().resource::<AssetServer>();
         asset_server.load("valid_particle_system.ron")
     };
@@ -129,7 +129,7 @@ fn test_bevy_loads_valid_ron_particle_system() {
         "Should load valid particle system RON"
     );
 
-    let assets = app.world().resource::<Assets<ParticleSystemAsset>>();
+    let assets = app.world().resource::<Assets<ParticlesAsset>>();
     let asset = assets.get(&handle).expect("Asset should be available");
 
     assert_eq!(asset.name, "Test Particle System");
@@ -142,7 +142,7 @@ fn test_bevy_loads_valid_ron_particle_system() {
 fn test_bevy_loads_valid_whatever_extension_particle_system() {
     let mut app = create_test_app();
 
-    let handle: Handle<ParticleSystemAsset> = {
+    let handle: Handle<ParticlesAsset> = {
         let asset_server = app.world().resource::<AssetServer>();
         asset_server.load("valid_particle_system.whatever")
     };
@@ -152,7 +152,7 @@ fn test_bevy_loads_valid_whatever_extension_particle_system() {
         "Should load particle system with .whatever extension"
     );
 
-    let assets = app.world().resource::<Assets<ParticleSystemAsset>>();
+    let assets = app.world().resource::<Assets<ParticlesAsset>>();
     let asset = assets.get(&handle).expect("Asset should be available");
 
     assert_eq!(asset.name, "Test Particle System (Whatever Extension)");
@@ -163,7 +163,7 @@ fn test_bevy_loads_valid_whatever_extension_particle_system() {
 fn test_bevy_fails_to_load_invalid_ron_as_particle_system() {
     let mut app = create_test_app();
 
-    let handle: Handle<ParticleSystemAsset> = {
+    let handle: Handle<ParticlesAsset> = {
         let asset_server = app.world().resource::<AssetServer>();
         asset_server.load("invalid_particle_system.ron")
     };
@@ -200,7 +200,7 @@ fn test_bevy_loads_dummy_data_ron() {
 fn test_bevy_coexisting_ron_loaders_load_correct_types() {
     let mut app = create_test_app();
 
-    let particle_handle: Handle<ParticleSystemAsset> = {
+    let particle_handle: Handle<ParticlesAsset> = {
         let asset_server = app.world().resource::<AssetServer>();
         asset_server.load("valid_particle_system.ron")
     };
@@ -220,7 +220,7 @@ fn test_bevy_coexisting_ron_loaders_load_correct_types() {
         "DummyData should load from dummy_data.ron"
     );
 
-    let particle_assets = app.world().resource::<Assets<ParticleSystemAsset>>();
+    let particle_assets = app.world().resource::<Assets<ParticlesAsset>>();
     let particle = particle_assets
         .get(&particle_handle)
         .expect("Particle system should be available");
@@ -250,7 +250,7 @@ fn test_bevy_wrong_loader_for_wrong_data_fails() {
 
 #[test]
 fn test_particle_system_loader_extension() {
-    let loader = ParticleSystemAssetLoader;
+    let loader = ParticlesAssetLoader;
     let extensions = loader.extensions();
     assert_eq!(extensions, &["ron"]);
 }

--- a/crates/bevy_sprinkles/tests/asset_loader.rs
+++ b/crates/bevy_sprinkles/tests/asset_loader.rs
@@ -249,7 +249,7 @@ fn test_bevy_wrong_loader_for_wrong_data_fails() {
 }
 
 #[test]
-fn test_particle_system_loader_extension() {
+fn test_particles_loader_extension() {
     let loader = ParticlesAssetLoader;
     let extensions = loader.extensions();
     assert_eq!(extensions, &["ron"]);

--- a/crates/bevy_sprinkles_editor/build.rs
+++ b/crates/bevy_sprinkles_editor/build.rs
@@ -65,7 +65,7 @@ fn main() {
             "    embedded_asset!(app, \"out\", \"assets/examples/{stem}.jpg\");\n"
         ));
     }
-    thumbnails.push_str("}");
+    thumbnails.push('}');
 
     fs::write(out_path.join("embed_thumbnails.rs"), thumbnails).unwrap();
 }

--- a/crates/bevy_sprinkles_editor/src/plugin.rs
+++ b/crates/bevy_sprinkles_editor/src/plugin.rs
@@ -68,7 +68,7 @@ fn load_initial_project(
     mut editor_state: ResMut<EditorState>,
     mut editor_data: ResMut<EditorData>,
     mut dirty_state: ResMut<DirtyState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
 ) {
     if let Some(file) = &cli_args.initial_file {
         let cwd_path = working_dir().join(file);
@@ -135,9 +135,9 @@ fn load_initial_project(
         }
     }
 
-    let asset = ParticleSystemAsset::new(
+    let asset = ParticlesAsset::new(
         "New project".to_string(),
-        ParticleSystemDimension::D3,
+        ParticlesDimension::D3,
         Default::default(),
         vec![EmitterData {
             name: "Emitter 1".to_string(),

--- a/crates/bevy_sprinkles_editor/src/project.rs
+++ b/crates/bevy_sprinkles_editor/src/project.rs
@@ -92,7 +92,7 @@ fn on_open_project_event(
     event: On<OpenProjectEvent>,
     mut editor_state: ResMut<EditorState>,
     mut editor_data: ResMut<EditorData>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     mut commands: Commands,
 ) {
@@ -207,7 +207,7 @@ fn poll_browse_open_result(result: Option<Res<BrowseOpenResult>>, mut commands: 
 
 pub fn save_project_to_path(
     path: PathBuf,
-    asset: &bevy_sprinkles::asset::ParticleSystemAsset,
+    asset: &bevy_sprinkles::asset::ParticlesAsset,
     result: Arc<Mutex<Option<SaveResultStatus>>>,
 ) {
     let Ok(contents) = ron::ser::to_string_pretty(asset, ron::ser::PrettyConfig::default()) else {
@@ -243,7 +243,7 @@ pub fn save_project_to_path(
 fn on_save_project_event(
     _event: On<SaveProjectEvent>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     mut commands: Commands,
 ) {
@@ -267,7 +267,7 @@ fn on_save_project_event(
 fn on_save_project_as_event(
     _event: On<SaveProjectAsEvent>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut commands: Commands,
 ) {
     let Some(handle) = &editor_state.current_project else {

--- a/crates/bevy_sprinkles_editor/src/state.rs
+++ b/crates/bevy_sprinkles_editor/src/state.rs
@@ -17,7 +17,7 @@ pub fn plugin(app: &mut App) {
 
 #[derive(Resource, Default)]
 pub struct EditorState {
-    pub current_project: Option<Handle<ParticleSystemAsset>>,
+    pub current_project: Option<Handle<ParticlesAsset>>,
     pub current_project_path: Option<PathBuf>,
     pub inspecting: Option<Inspecting>,
 }
@@ -25,7 +25,7 @@ pub struct EditorState {
 impl EditorState {
     pub fn open_project(
         &mut self,
-        handle: Handle<ParticleSystemAsset>,
+        handle: Handle<ParticlesAsset>,
         path: PathBuf,
         dirty_state: &mut DirtyState,
     ) {
@@ -94,7 +94,7 @@ pub struct PlaybackSeekEvent(pub f32);
 fn update_window_title(
     editor_state: Res<EditorState>,
     dirty_state: Res<DirtyState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut window: Query<&mut Window, With<PrimaryWindow>>,
 ) {
     if !editor_state.is_changed() && !dirty_state.is_changed() {

--- a/crates/bevy_sprinkles_editor/src/ui/components/binding/commit.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/binding/commit.rs
@@ -25,7 +25,7 @@ use super::{
 pub(super) struct CommitContext<'w, 's> {
     commands: Commands<'w, 's>,
     editor_state: Res<'w, EditorState>,
-    assets: ResMut<'w, Assets<ParticleSystemAsset>>,
+    assets: ResMut<'w, Assets<ParticlesAsset>>,
     editor_data: ResMut<'w, EditorData>,
     dirty_state: ResMut<'w, DirtyState>,
     bindings: Query<'w, 's, &'static FieldBinding>,

--- a/crates/bevy_sprinkles_editor/src/ui/components/binding/mod.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/binding/mod.rs
@@ -25,7 +25,7 @@ pub(super) const MAX_ANCESTOR_DEPTH: usize = 10;
 
 pub(crate) fn get_inspecting_emitter<'a>(
     editor_state: &EditorState,
-    assets: &'a Assets<ParticleSystemAsset>,
+    assets: &'a Assets<ParticlesAsset>,
 ) -> Option<(u8, &'a EmitterData)> {
     let inspecting = match &editor_state.inspecting {
         Some(i) if i.kind == Inspectable::Emitter => i,
@@ -39,7 +39,7 @@ pub(crate) fn get_inspecting_emitter<'a>(
 
 pub(super) fn get_inspecting_emitter_mut<'a>(
     editor_state: &EditorState,
-    assets: &'a mut Assets<ParticleSystemAsset>,
+    assets: &'a mut Assets<ParticlesAsset>,
 ) -> Option<(u8, &'a mut EmitterData)> {
     let inspecting = match &editor_state.inspecting {
         Some(i) if i.kind == Inspectable::Emitter => i,
@@ -53,7 +53,7 @@ pub(super) fn get_inspecting_emitter_mut<'a>(
 
 pub(super) fn get_inspecting_collider<'a>(
     editor_state: &EditorState,
-    assets: &'a Assets<ParticleSystemAsset>,
+    assets: &'a Assets<ParticlesAsset>,
 ) -> Option<(u8, &'a ColliderData)> {
     let inspecting = match &editor_state.inspecting {
         Some(i) if i.kind == Inspectable::Collider => i,
@@ -67,7 +67,7 @@ pub(super) fn get_inspecting_collider<'a>(
 
 pub(super) fn get_inspecting_collider_mut<'a>(
     editor_state: &EditorState,
-    assets: &'a mut Assets<ParticleSystemAsset>,
+    assets: &'a mut Assets<ParticlesAsset>,
 ) -> Option<(u8, &'a mut ColliderData)> {
     let inspecting = match &editor_state.inspecting {
         Some(i) if i.kind == Inspectable::Collider => i,
@@ -81,7 +81,7 @@ pub(super) fn get_inspecting_collider_mut<'a>(
 
 pub(super) fn get_inspected_data<'a>(
     editor_state: &EditorState,
-    assets: &'a Assets<ParticleSystemAsset>,
+    assets: &'a Assets<ParticlesAsset>,
 ) -> Option<&'a dyn Reflect> {
     let inspecting = editor_state.inspecting.as_ref()?;
     let handle = editor_state.current_project.as_ref()?;
@@ -100,7 +100,7 @@ pub(super) fn get_inspected_data<'a>(
 
 pub(super) fn get_inspected_data_mut<'a>(
     editor_state: &EditorState,
-    assets: &'a mut Assets<ParticleSystemAsset>,
+    assets: &'a mut Assets<ParticlesAsset>,
 ) -> Option<&'a mut dyn Reflect> {
     let inspecting = editor_state.inspecting.as_ref()?;
     let handle = editor_state.current_project.as_ref()?;
@@ -119,7 +119,7 @@ pub(super) fn get_inspected_data_mut<'a>(
 
 pub(super) fn get_asset_data<'a>(
     editor_state: &EditorState,
-    assets: &'a Assets<ParticleSystemAsset>,
+    assets: &'a Assets<ParticlesAsset>,
 ) -> Option<&'a dyn Reflect> {
     let handle = editor_state.current_project.as_ref()?;
     let asset = assets.get(handle)?;
@@ -128,7 +128,7 @@ pub(super) fn get_asset_data<'a>(
 
 pub(super) fn get_asset_data_mut<'a>(
     editor_state: &EditorState,
-    assets: &'a mut Assets<ParticleSystemAsset>,
+    assets: &'a mut Assets<ParticlesAsset>,
 ) -> Option<&'a mut dyn Reflect> {
     let handle = editor_state.current_project.as_ref()?;
     let asset = assets.get_mut(handle)?;
@@ -138,7 +138,7 @@ pub(super) fn get_asset_data_mut<'a>(
 pub(super) fn resolve_binding_data<'a>(
     binding: &FieldBinding,
     editor_state: &EditorState,
-    assets: &'a Assets<ParticleSystemAsset>,
+    assets: &'a Assets<ParticlesAsset>,
     editor_data: &'a EditorData,
 ) -> Option<&'a dyn Reflect> {
     match binding.target {
@@ -151,7 +151,7 @@ pub(super) fn resolve_binding_data<'a>(
 pub(super) fn resolve_binding_data_mut<'a>(
     binding: &FieldBinding,
     editor_state: &EditorState,
-    assets: &'a mut Assets<ParticleSystemAsset>,
+    assets: &'a mut Assets<ParticlesAsset>,
     editor_data: &'a mut EditorData,
 ) -> Option<&'a mut dyn Reflect> {
     match binding.target {
@@ -780,7 +780,7 @@ pub(super) fn mark_dirty_and_restart(
 #[derive(SystemParam)]
 pub(crate) struct EmitterWriter<'w, 's> {
     editor_state: Res<'w, EditorState>,
-    assets: ResMut<'w, Assets<ParticleSystemAsset>>,
+    assets: ResMut<'w, Assets<ParticlesAsset>>,
     dirty_state: ResMut<'w, DirtyState>,
     emitter_runtimes: Query<'w, 's, &'static mut EmitterRuntime>,
 }

--- a/crates/bevy_sprinkles_editor/src/ui/components/binding/swatch.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/binding/swatch.rs
@@ -60,7 +60,7 @@ fn spawn_swatch_material(
 pub(super) fn setup_variant_swatch(
     mut commands: Commands,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     new_swatch_slots: Query<(Entity, &VariantEditSwatchSlot), Added<VariantEditSwatchSlot>>,
     changed_configs: Query<(Entity, &VariantEditConfig, &FieldBinding), Changed<VariantEditConfig>>,
     variant_edit_configs: Query<(&VariantEditConfig, &FieldBinding), With<EditorVariantEdit>>,

--- a/crates/bevy_sprinkles_editor/src/ui/components/binding/sync.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/binding/sync.rs
@@ -23,7 +23,7 @@ use super::{
 
 pub(super) fn bind_text_inputs(
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     editor_data: Res<EditorData>,
     tracker: Res<InspectedEmitterTracker>,
     new_bindings: Query<Entity, Added<FieldBinding>>,
@@ -68,7 +68,7 @@ pub(super) fn bind_text_inputs(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn bind_widget_values(
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     editor_data: Res<EditorData>,
     tracker: Res<InspectedEmitterTracker>,
     new_bindings: Query<Entity, Added<FieldBinding>>,
@@ -184,7 +184,7 @@ pub(super) fn bind_widget_values(
 pub(super) fn bind_color_pickers(
     mut commands: Commands,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     editor_data: Res<EditorData>,
     mut color_pickers: Query<
         (Entity, &mut ColorPickerState, &FieldBinding),

--- a/crates/bevy_sprinkles_editor/src/ui/components/data_panel.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/data_panel.rs
@@ -46,7 +46,7 @@ pub fn plugin(app: &mut App) {
 
 #[derive(Resource, Default)]
 struct LastLoadedProject {
-    handle: Option<AssetId<ParticleSystemAsset>>,
+    handle: Option<AssetId<ParticlesAsset>>,
 }
 
 #[derive(Component)]
@@ -143,7 +143,7 @@ fn rebuild_lists(
     mut commands: Commands,
     editor_state: Res<EditorState>,
     mut last_project: ResMut<LastLoadedProject>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     emitters_section: Query<(Entity, &Children), With<EmittersSection>>,
     colliders_section: Query<(Entity, &Children), With<CollidersSection>>,
     existing_wrappers: Query<Entity, With<ItemsList>>,
@@ -283,7 +283,7 @@ fn on_add_emitter(
     _event: On<AddEmitterEvent>,
     mut commands: Commands,
     mut editor_state: ResMut<EditorState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     mut last_project: ResMut<LastLoadedProject>,
 ) {
@@ -318,7 +318,7 @@ fn on_add_collider(
     _event: On<AddColliderEvent>,
     mut commands: Commands,
     mut editor_state: ResMut<EditorState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     mut last_project: ResMut<LastLoadedProject>,
 ) {
@@ -372,7 +372,7 @@ fn on_item_menu_change(
     event: On<ComboBoxChangeEvent>,
     mut commands: Commands,
     mut editor_state: ResMut<EditorState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     mut last_project: ResMut<LastLoadedProject>,
     menus: Query<&ChildOf, With<ItemMenu>>,
@@ -578,7 +578,7 @@ fn strip_trailing_number(name: &str) -> (&str, Option<u32>) {
 
 fn get_item_name(
     editor_state: &EditorState,
-    assets: &Assets<ParticleSystemAsset>,
+    assets: &Assets<ParticlesAsset>,
     item: &InspectableItem,
 ) -> Option<String> {
     let handle = editor_state.current_project.as_ref()?;
@@ -616,7 +616,7 @@ fn handle_item_double_click(
     time: Res<Time<Real>>,
     mouse: Res<ButtonInput<MouseButton>>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     items: Query<(Entity, &InspectableItem, &Children), Without<Renaming>>,
     mut buttons: Query<(Entity, &Hovered, &mut Node), With<ItemButton>>,
     mut last_click: Local<(Option<Entity>, f32)>,
@@ -706,7 +706,7 @@ fn on_rename_commit(
     mut button_texts: Query<&mut Text>,
     button_children: Query<&Children, With<EditorButton>>,
     editor_state: Res<EditorState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     mut emitter_runtimes: Query<&mut EmitterRuntime>,
 ) {
@@ -774,7 +774,7 @@ fn on_delete_confirmed(
     pending: Option<Res<PendingDelete>>,
     mut commands: Commands,
     mut editor_state: ResMut<EditorState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     mut last_project: ResMut<LastLoadedProject>,
 ) {

--- a/crates/bevy_sprinkles_editor/src/ui/components/examples_dialog.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/examples_dialog.rs
@@ -2,7 +2,7 @@ use bevy::color::palettes::tailwind;
 use bevy::picking::hover::Hovered;
 use bevy::prelude::*;
 
-use bevy_sprinkles::asset::{ParticleSystemAuthors, ParticleSystemDimension};
+use bevy_sprinkles::asset::{ParticleSystemAuthors, ParticlesDimension};
 
 use crate::assets::example_thumbnail_path;
 use crate::io::examples_dir;
@@ -41,7 +41,7 @@ struct ExampleCardActive;
 struct ExampleEntry {
     name: String,
     path: String,
-    dimension: ParticleSystemDimension,
+    dimension: ParticlesDimension,
     thumbnail: String,
     authors: ParticleSystemAuthors,
 }
@@ -218,8 +218,8 @@ fn spawn_example_card(
     ));
 
     let dimension_label = match entry.dimension {
-        ParticleSystemDimension::D3 => "3D",
-        ParticleSystemDimension::D2 => "2D",
+        ParticlesDimension::D3 => "3D",
+        ParticlesDimension::D2 => "2D",
     };
 
     let name_row = commands

--- a/crates/bevy_sprinkles_editor/src/ui/components/examples_dialog.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/examples_dialog.rs
@@ -2,7 +2,7 @@ use bevy::color::palettes::tailwind;
 use bevy::picking::hover::Hovered;
 use bevy::prelude::*;
 
-use bevy_sprinkles::asset::{ParticleSystemAuthors, ParticlesDimension};
+use bevy_sprinkles::asset::{ParticlesAuthors, ParticlesDimension};
 
 use crate::assets::example_thumbnail_path;
 use crate::io::examples_dir;
@@ -43,7 +43,7 @@ struct ExampleEntry {
     path: String,
     dimension: ParticlesDimension,
     thumbnail: String,
-    authors: ParticleSystemAuthors,
+    authors: ParticlesAuthors,
 }
 
 #[derive(Resource)]

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/collider_properties.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/collider_properties.rs
@@ -63,7 +63,7 @@ fn setup_collider_content(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     sections: Query<(Entity, &InspectorSection), With<ColliderPropertiesSection>>,
     existing: Query<Entity, With<ColliderPropertiesContent>>,
 ) {
@@ -139,7 +139,7 @@ fn handle_collider_shape_change(
     mut commands: Commands,
     shape_comboboxes: Query<(), With<ColliderShapeComboBox>>,
     editor_state: Res<EditorState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     existing: Query<Entity, With<ColliderPropertiesContent>>,
 ) {
@@ -174,7 +174,7 @@ fn handle_collider_text_commit(
     parents: Query<&ChildOf>,
     shape_fields: Query<(&ColliderShapeField, &Children)>,
     editor_state: Res<EditorState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
 ) {
     let Ok(value) = trigger.text.parse::<f32>() else {

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/colors.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/colors.rs
@@ -114,7 +114,7 @@ fn setup_alpha_alert(
 fn sync_alpha_disabled(
     mut commands: Commands,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut alert_nodes: Query<&mut Node, With<AlphaOpaqueAlert>>,
     new_alerts: Query<Entity, Added<AlphaOpaqueAlert>>,
     fields: Query<(Entity, &FieldBinding)>,

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/draw_pass.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/draw_pass.rs
@@ -239,10 +239,7 @@ fn find_ancestor_child_of(
     None
 }
 
-fn extract_mask_cutoff(
-    editor_state: &EditorState,
-    assets: &Assets<ParticleSystemAsset>,
-) -> Option<f32> {
+fn extract_mask_cutoff(editor_state: &EditorState, assets: &Assets<ParticlesAsset>) -> Option<f32> {
     let (_, emitter) = get_inspecting_emitter(editor_state, assets)?;
     let DrawPassMaterial::Standard(mat) = &emitter.draw_pass.material else {
         return None;
@@ -323,7 +320,7 @@ fn spawn_cutoff_row(
 fn sync_mask_cutoff(
     mut commands: Commands,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     existing: Query<Entity, With<MaskCutoffRow>>,
     bindings: Query<(Entity, &FieldBinding)>,
     parents: Query<&ChildOf>,
@@ -361,7 +358,7 @@ fn sync_mask_cutoff(
 fn sync_trail_mesh_alert(
     mut commands: Commands,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     sections: Query<(Entity, &InspectorSection, &Children), With<DrawPassSection>>,
     existing: Query<Entity, With<TrailMeshAlert>>,
     mut alert_nodes: Query<&mut Node, With<TrailMeshAlert>>,

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/mod.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/mod.rs
@@ -475,7 +475,7 @@ fn setup_inspector_section_fields(
 
 fn get_outliner_title(
     editor_state: &EditorState,
-    assets: &Assets<ParticleSystemAsset>,
+    assets: &Assets<ParticlesAsset>,
 ) -> Option<(String, &'static str)> {
     let inspecting = editor_state.inspecting.as_ref()?;
     let handle = editor_state.current_project.as_ref()?;
@@ -497,7 +497,7 @@ fn get_outliner_title(
 fn update_panel_title(
     editor_state: Res<EditorState>,
     active_tab: Res<ActiveSidebarTab>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut title_text: Query<&mut Text, With<PanelTitleText>>,
     mut title_icon: Query<&mut ImageNode, With<PanelTitleIcon>>,
     asset_server: Res<AssetServer>,

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/particle_flags.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/particle_flags.rs
@@ -41,7 +41,7 @@ fn setup_particle_flags_content(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     sections: Query<(Entity, &InspectorSection), With<ParticleFlagsSection>>,
     existing: Query<Entity, With<ParticleFlagsContent>>,
 ) {
@@ -81,7 +81,7 @@ fn setup_particle_flags_content(
 
 fn sync_particle_flags(
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut flag_checkboxes: Query<(&ParticleFlagCheckbox, &mut CheckboxState)>,
 ) {
     if !editor_state.is_changed() {
@@ -104,7 +104,7 @@ fn handle_particle_flag_checkbox(
     trigger: On<CheckboxCommitEvent>,
     flag_checkboxes: Query<&ParticleFlagCheckbox>,
     editor_state: Res<EditorState>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     mut emitter_runtimes: Query<&mut EmitterRuntime>,
 ) {

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/sub_emitter.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/sub_emitter.rs
@@ -67,10 +67,7 @@ fn mode_options() -> Vec<ComboBoxOptionData> {
     ]
 }
 
-fn target_options(
-    asset: &ParticleSystemAsset,
-    current_emitter_index: usize,
-) -> Vec<ComboBoxOptionData> {
+fn target_options(asset: &ParticlesAsset, current_emitter_index: usize) -> Vec<ComboBoxOptionData> {
     asset
         .emitters
         .iter()
@@ -82,7 +79,7 @@ fn target_options(
 
 fn target_combo_index(
     config: &Option<SubEmitterConfig>,
-    asset: &ParticleSystemAsset,
+    asset: &ParticlesAsset,
     current_emitter_index: usize,
 ) -> usize {
     let target = match config {
@@ -103,7 +100,7 @@ fn setup_sub_emitter_content(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     sections: Query<(Entity, &InspectorSection), With<SubEmitterSection>>,
     existing: Query<Entity, With<SubEmitterContent>>,
 ) {
@@ -162,7 +159,7 @@ fn setup_sub_emitter_content(
 fn spawn_fields(
     parent: &mut ChildSpawnerCommands,
     config: &SubEmitterConfig,
-    asset: &ParticleSystemAsset,
+    asset: &ParticlesAsset,
     current_emitter_index: usize,
     font: &Handle<Font>,
     asset_server: &AssetServer,

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/trail.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/trail.rs
@@ -48,7 +48,7 @@ fn setup_trail_options(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     sections: Query<(Entity, &InspectorSection), With<TrailSection>>,
     existing: Query<Entity, With<TrailOptions>>,
 ) {
@@ -118,7 +118,7 @@ fn setup_trail_options(
 
 fn toggle_trail_options(
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut options: Query<&mut Node, With<TrailOptions>>,
 ) {
     let Ok(mut node) = options.single_mut() else {
@@ -134,7 +134,7 @@ fn toggle_trail_options(
 
 fn sync_trail_no_mesh_alert(
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut alert_nodes: Query<&mut Node, With<TrailNoMeshAlert>>,
     new_alerts: Query<Entity, Added<TrailNoMeshAlert>>,
 ) {

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/turbulence.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/turbulence.rs
@@ -40,7 +40,7 @@ fn setup_turbulence_options(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     sections: Query<(Entity, &InspectorSection), With<TurbulenceSection>>,
     existing: Query<Entity, With<TurbulenceOptions>>,
 ) {
@@ -104,7 +104,7 @@ fn setup_turbulence_options(
 
 fn toggle_turbulence_options(
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut options: Query<&mut Node, With<TurbulenceOptions>>,
 ) {
     let Ok(mut node) = options.single_mut() else {

--- a/crates/bevy_sprinkles_editor/src/ui/components/inspector/velocities.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/inspector/velocities.rs
@@ -113,7 +113,7 @@ pub fn velocities_section(asset_server: &AssetServer) -> impl Bundle {
 
 fn get_active_animated_velocities(
     editor_state: &EditorState,
-    assets: &Assets<ParticleSystemAsset>,
+    assets: &Assets<ParticlesAsset>,
 ) -> Vec<String> {
     let Some((_, emitter)) = get_inspecting_emitter(editor_state, assets) else {
         return Vec::new();
@@ -154,7 +154,7 @@ fn setup_velocity_list(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut lists: Query<(Entity, &mut VelocityList, &InspectorSection)>,
     existing_containers: Query<Entity, With<VelocityListContainer>>,
 ) {

--- a/crates/bevy_sprinkles_editor/src/ui/components/project_selector.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/project_selector.rs
@@ -147,7 +147,7 @@ fn setup_project_selector(
 fn update_project_label(
     editor_state: Res<EditorState>,
     dirty_state: Res<DirtyState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     triggers: Query<&Children, With<ProjectSelectorTrigger>>,
     mut texts: Query<&mut Text>,
 ) {
@@ -771,7 +771,7 @@ fn handle_create_project(
     state: Option<Res<NewProjectDialogState>>,
     mut editor_state: ResMut<EditorState>,
     mut editor_data: ResMut<EditorData>,
-    mut assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut assets: ResMut<Assets<ParticlesAsset>>,
     mut dirty_state: ResMut<DirtyState>,
     children_query: Query<&Children>,
     text_edits: Query<Entity, With<EditorTextEdit>>,
@@ -812,9 +812,9 @@ fn handle_create_project(
         let _ = std::fs::create_dir_all(parent);
     }
 
-    let asset = ParticleSystemAsset::new(
+    let asset = ParticlesAsset::new(
         name,
-        ParticleSystemDimension::D3,
+        ParticlesDimension::D3,
         Default::default(),
         vec![EmitterData {
             name: "Emitter 1".to_string(),

--- a/crates/bevy_sprinkles_editor/src/ui/components/seekbar.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/seekbar.rs
@@ -62,7 +62,7 @@ pub fn seekbar(asset_server: &AssetServer) -> impl Bundle {
                 SeekbarElapsed,
                 Text::new("0.00"),
                 TextFont {
-                    font: font.clone().into(),
+                    font: font.clone(),
                     font_size: LABEL_SIZE,
                     font_features: tabular_figures.clone(),
                     weight: FontWeight::MEDIUM,
@@ -117,7 +117,7 @@ pub fn seekbar(asset_server: &AssetServer) -> impl Bundle {
                 SeekbarDuration,
                 Text::new("0.00s"),
                 TextFont {
-                    font: font.into(),
+                    font,
                     font_size: LABEL_SIZE,
                     font_features: tabular_figures,
                     weight: FontWeight::MEDIUM,
@@ -164,7 +164,7 @@ fn update_seekbar(
         return;
     };
 
-    let Some(asset) = assets.get(&particle_system.handle) else {
+    let Some(asset) = assets.get(particle_system) else {
         return;
     };
 
@@ -279,7 +279,7 @@ fn on_seekbar_drag(
         return;
     };
 
-    let Some(asset) = assets.get(&particle_system.handle) else {
+    let Some(asset) = assets.get(particle_system) else {
         return;
     };
 

--- a/crates/bevy_sprinkles_editor/src/ui/components/seekbar.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/components/seekbar.rs
@@ -148,8 +148,8 @@ fn setup_seekbar_observers(hitboxes: Query<Entity, Added<SeekbarHitbox>>, mut co
 }
 
 fn update_seekbar(
-    assets: Res<Assets<ParticleSystemAsset>>,
-    system_query: Query<(Entity, &ParticleSystem3D), With<EditorParticlePreview>>,
+    assets: Res<Assets<ParticlesAsset>>,
+    system_query: Query<(Entity, &Particles3d), With<EditorParticlePreview>>,
     emitter_query: Query<(&EmitterEntity, &EmitterRuntime)>,
     mut elapsed_label: Query<&mut Text, (With<SeekbarElapsed>, Without<SeekbarDuration>)>,
     mut duration_label: Query<&mut Text, (With<SeekbarDuration>, Without<SeekbarElapsed>)>,
@@ -271,8 +271,8 @@ fn on_drag_end(
 fn on_seekbar_drag(
     event: On<SeekbarDragEvent>,
     mut commands: Commands,
-    assets: Res<Assets<ParticleSystemAsset>>,
-    system_query: Query<&ParticleSystem3D, With<EditorParticlePreview>>,
+    assets: Res<Assets<ParticlesAsset>>,
+    system_query: Query<&Particles3d, With<EditorParticlePreview>>,
     mut hitboxes: Query<&mut SeekbarDragState, With<SeekbarHitbox>>,
 ) {
     let Some(particle_system) = system_query.iter().next() else {

--- a/crates/bevy_sprinkles_editor/src/ui/widgets/texture_edit.rs
+++ b/crates/bevy_sprinkles_editor/src/ui/widgets/texture_edit.rs
@@ -132,7 +132,7 @@ fn setup_texture_content(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    p_assets: Res<Assets<ParticleSystemAsset>>,
+    p_assets: Res<Assets<ParticlesAsset>>,
     containers: Query<(Entity, &VariantFieldsContainer), Added<VariantFieldsContainer>>,
     configs: Query<&VariantEditConfig, With<EditorVariantEdit>>,
     bindings: Query<&FieldBinding>,
@@ -182,7 +182,7 @@ fn respawn_texture_content_on_switch(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    p_assets: Res<Assets<ParticleSystemAsset>>,
+    p_assets: Res<Assets<ParticlesAsset>>,
     changed_configs: Query<(Entity, &VariantEditConfig), Changed<VariantEditConfig>>,
     mut containers: Query<(
         Entity,
@@ -715,7 +715,7 @@ fn poll_texture_file_pick(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     editor_state: Res<EditorState>,
-    mut particle_assets: ResMut<Assets<ParticleSystemAsset>>,
+    mut particle_assets: ResMut<Assets<ParticlesAsset>>,
     pick_result: Option<Res<TextureFilePickResult>>,
     mut configs: Query<&mut VariantEditConfig, With<EditorVariantEdit>>,
     preview_images: Query<(Entity, &TexturePreviewImage, Option<&Children>)>,
@@ -815,7 +815,7 @@ fn poll_texture_file_pick(
 fn read_current_texture_ref(
     variant_edit: Entity,
     editor_state: &EditorState,
-    assets: &Assets<ParticleSystemAsset>,
+    assets: &Assets<ParticlesAsset>,
     bindings: &Query<&FieldBinding>,
     configs: &Query<&VariantEditConfig, With<EditorVariantEdit>>,
 ) -> Option<TextureRef> {

--- a/crates/bevy_sprinkles_editor/src/viewport.rs
+++ b/crates/bevy_sprinkles_editor/src/viewport.rs
@@ -236,7 +236,7 @@ pub struct EditorParticlePreview;
 pub fn spawn_preview_particle_system(
     mut commands: Commands,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     existing: Query<Entity, With<EditorParticlePreview>>,
 ) {
     let Some(handle) = &editor_state.current_project else {
@@ -255,7 +255,7 @@ pub fn spawn_preview_particle_system(
     }
 
     commands.spawn((
-        ParticleSystem3D {
+        Particles3d {
             handle: handle.clone(),
         },
         asset.initial_transform.to_transform(),
@@ -269,7 +269,7 @@ pub fn spawn_preview_particle_system(
 pub fn despawn_preview_on_project_change(
     mut commands: Commands,
     editor_state: Res<EditorState>,
-    existing: Query<(Entity, &ParticleSystem3D), With<EditorParticlePreview>>,
+    existing: Query<(Entity, &Particles3d), With<EditorParticlePreview>>,
 ) {
     if !editor_state.is_changed() {
         return;
@@ -333,7 +333,7 @@ pub fn respawn_preview_on_emitter_change(
     _trigger: On<PlaybackResetEvent>,
     mut commands: Commands,
     editor_state: Res<EditorState>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     preview_query: Query<Entity, (With<EditorParticlePreview>, With<ParticleSystemRuntime>)>,
     emitter_query: Query<&EmitterEntity>,
 ) {
@@ -363,9 +363,9 @@ pub fn respawn_preview_on_emitter_change(
 
 pub fn handle_playback_reset_event(
     _trigger: On<PlaybackResetEvent>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut system_query: Query<
-        (Entity, &ParticleSystem3D, &mut ParticleSystemRuntime),
+        (Entity, &Particles3d, &mut ParticleSystemRuntime),
         With<EditorParticlePreview>,
     >,
     mut emitter_query: Query<(&EmitterEntity, &mut EmitterRuntime)>,
@@ -390,9 +390,9 @@ pub fn handle_playback_reset_event(
 
 pub fn handle_playback_play_event(
     _trigger: On<PlaybackPlayEvent>,
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     mut system_query: Query<
-        (Entity, &ParticleSystem3D, &mut ParticleSystemRuntime),
+        (Entity, &Particles3d, &mut ParticleSystemRuntime),
         With<EditorParticlePreview>,
     >,
     mut emitter_query: Query<(&EmitterEntity, &mut EmitterRuntime)>,
@@ -499,10 +499,10 @@ pub fn draw_collider_gizmos(
 }
 
 pub fn sync_playback_state(
-    assets: Res<Assets<ParticleSystemAsset>>,
+    assets: Res<Assets<ParticlesAsset>>,
     drag_state: Query<&SeekbarDragState>,
     mut system_query: Query<
-        (Entity, &ParticleSystem3D, &mut ParticleSystemRuntime),
+        (Entity, &Particles3d, &mut ParticleSystemRuntime),
         With<EditorParticlePreview>,
     >,
     mut emitter_query: Query<(&EmitterEntity, &mut EmitterRuntime)>,

--- a/crates/bevy_sprinkles_editor/src/viewport.rs
+++ b/crates/bevy_sprinkles_editor/src/viewport.rs
@@ -255,9 +255,7 @@ pub fn spawn_preview_particle_system(
     }
 
     commands.spawn((
-        Particles3d {
-            handle: handle.clone(),
-        },
+        Particles3d(handle.clone()),
         asset.initial_transform.to_transform(),
         Visibility::default(),
         EditorMode,
@@ -277,7 +275,7 @@ pub fn despawn_preview_on_project_change(
 
     for (entity, particle_system) in existing.iter() {
         let should_despawn = match &editor_state.current_project {
-            Some(handle) => particle_system.handle != *handle,
+            Some(handle) => **particle_system != *handle,
             None => true,
         };
 
@@ -371,7 +369,7 @@ pub fn handle_playback_reset_event(
     mut emitter_query: Query<(&EmitterEntity, &mut EmitterRuntime)>,
 ) {
     for (system_entity, particle_system, mut system_runtime) in system_query.iter_mut() {
-        let Some(asset) = assets.get(&particle_system.handle) else {
+        let Some(asset) = assets.get(particle_system) else {
             continue;
         };
 
@@ -398,7 +396,7 @@ pub fn handle_playback_play_event(
     mut emitter_query: Query<(&EmitterEntity, &mut EmitterRuntime)>,
 ) {
     for (system_entity, particle_system, mut system_runtime) in system_query.iter_mut() {
-        let Some(asset) = assets.get(&particle_system.handle) else {
+        let Some(asset) = assets.get(particle_system) else {
             continue;
         };
 
@@ -510,7 +508,7 @@ pub fn sync_playback_state(
     let is_seeking = drag_state.iter().any(|s| s.dragging);
 
     for (system_entity, particle_system, mut system_runtime) in system_query.iter_mut() {
-        let Some(asset) = assets.get(&particle_system.handle) else {
+        let Some(asset) = assets.get(particle_system) else {
             continue;
         };
 


### PR DESCRIPTION
## What does this PR do?

- Renames ParticleSystem -> Particles to disambiguate user facing API from SystemSets.
- it touched: asset, dimension, 3d system, 2d system, authors
- Make Particles3d a unit struct (like bevys Mesh3d) and add some utis for usage ergonomics

Tbh the rename scale frightens me, not sure how it will sit with you. But I think for the user faced API its better.

## Related issues

Closes #24 

