### PR TITLE
add stop emitter method to runtime

### DIFF
--- a/crates/bevy_sprinkles/src/runtime.rs
+++ b/crates/bevy_sprinkles/src/runtime.rs
@@ -220,6 +220,11 @@ impl EmitterRuntime {
         }
     }
 
+    /// Stops emission but allows existing particles to continue simulating.
+    pub fn stop_emitting(&mut self) {
+        self.set_emitting(false);
+    }
+
     /// Starts or resumes emission, resetting the one-shot completed flag.
     pub fn play(&mut self) {
         self.set_emitting(true);


### PR DESCRIPTION
## What does this PR do?

stops the emitter from emitting particles, remaining particles continue with lifecycle.

## Related issues

#32 

## Screenshots

N/A
