### PR TITLE
fix: WASM/WebGPU support (closes #28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,7 @@ dependencies = [
  "ron 0.10.1",
  "serde",
  "thiserror 2.0.18",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bevy = { version = "0.18.0", default-features = false, features = [
     "ui_api",
     "ui_bevy_render",
     "picking",
-    "file_watcher",
     # "reflect_auto_register",
 ] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/bevy_sprinkles/Cargo.toml
+++ b/crates/bevy_sprinkles/Cargo.toml
@@ -25,3 +25,6 @@ bytemuck = { workspace = true }
 bitflags = { workspace = true }
 paste = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = "1"
+

--- a/crates/bevy_sprinkles/src/compute.rs
+++ b/crates/bevy_sprinkles/src/compute.rs
@@ -119,9 +119,20 @@ pub fn init_particle_compute_pipeline(
         ..linear_clamp_sampler
     });
 
-    let fallback_emission_buffer = render_device.create_buffer_with_data(
+    // dst and src need distinct buffers even when unused: WebGPU rejects two
+    // writable storage bindings aliasing the same buffer range, even if neither
+    // is read or written by the shader for this dispatch.
+    let fallback_emission_dst_buffer = render_device.create_buffer_with_data(
         &bevy::render::render_resource::BufferInitDescriptor {
-            label: Some("fallback_emission_buffer"),
+            label: Some("fallback_emission_dst_buffer"),
+            contents: &[0u8; 64],
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        },
+    );
+
+    let fallback_emission_src_buffer = render_device.create_buffer_with_data(
+        &bevy::render::render_resource::BufferInitDescriptor {
+            label: Some("fallback_emission_src_buffer"),
             contents: &[0u8; 64],
             usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
         },
@@ -141,7 +152,10 @@ pub fn init_particle_compute_pipeline(
     });
     commands.insert_resource(GradientSampler(gradient_sampler));
     commands.insert_resource(CurveSampler(curve_sampler));
-    commands.insert_resource(FallbackEmissionBuffer(fallback_emission_buffer));
+    commands.insert_resource(FallbackEmissionBuffers {
+        dst: fallback_emission_dst_buffer,
+        src: fallback_emission_src_buffer,
+    });
     commands.insert_resource(FallbackTrailHistoryBuffer(fallback_trail_history_buffer));
 }
 
@@ -152,7 +166,10 @@ pub struct GradientSampler(pub bevy::render::render_resource::Sampler);
 pub struct CurveSampler(pub bevy::render::render_resource::Sampler);
 
 #[derive(Resource)]
-pub struct FallbackEmissionBuffer(pub Buffer);
+pub struct FallbackEmissionBuffers {
+    pub dst: Buffer,
+    pub src: Buffer,
+}
 
 #[derive(Resource)]
 pub(crate) struct FallbackTrailHistoryBuffer(pub(crate) Buffer);
@@ -179,7 +196,7 @@ pub fn prepare_particle_compute_bind_groups(
     gpu_images: Res<RenderAssets<GpuImage>>,
     fallback_gradient_texture: Option<Res<FallbackGradientTexture>>,
     fallback_curve_texture: Option<Res<FallbackCurveTexture>>,
-    fallback_emission_buffer: Res<FallbackEmissionBuffer>,
+    fallback_emission_buffers: Res<FallbackEmissionBuffers>,
     fallback_trail_history_buffer: Res<FallbackTrailHistoryBuffer>,
     gradient_sampler: Res<GradientSampler>,
     curve_sampler: Res<CurveSampler>,
@@ -322,8 +339,8 @@ pub fn prepare_particle_compute_bind_groups(
             .and_then(|h| gpu_storage_buffers.get(h))
             .map(|b| &b.buffer);
 
-        let dst_binding = dst_buffer.unwrap_or(&fallback_emission_buffer.0);
-        let src_binding = src_buffer.unwrap_or(&fallback_emission_buffer.0);
+        let dst_binding = dst_buffer.unwrap_or(&fallback_emission_buffers.dst);
+        let src_binding = src_buffer.unwrap_or(&fallback_emission_buffers.src);
 
         let trail_history_buffer = emitter_data
             .trail_history_buffer_handle

--- a/crates/bevy_sprinkles/src/runtime.rs
+++ b/crates/bevy_sprinkles/src/runtime.rs
@@ -304,7 +304,11 @@ pub struct ColliderEntity {
 }
 
 fn rand_seed() -> u32 {
+    #[cfg(not(target_arch = "wasm32"))]
     use std::time::{SystemTime, UNIX_EPOCH};
+    #[cfg(target_arch = "wasm32")]
+    use web_time::{SystemTime, UNIX_EPOCH};
+
     let duration = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default();

--- a/crates/bevy_sprinkles_editor/Cargo.toml
+++ b/crates/bevy_sprinkles_editor/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-bevy = { workspace = true, features = ["jpeg"] }
+bevy = { workspace = true, features = ["jpeg", "file_watcher"] }
 bevy_sprinkles = { version = "0.2.0", path = "../bevy_sprinkles" }
 serde = { workspace = true }
 ron = { workspace = true }


### PR DESCRIPTION
Fixes the three blockers for running sprinkles in the browser via wasm32 + WebGPU, as reported in #28.

## Changes

### `file_watcher` is wasm-incompatible
Removed the `file_watcher` Bevy feature from the workspace dependency and added it back as an editor-only feature. The `notify` crate it pulls in doesn't compile to wasm, and the library itself never used asset hot-reload — only the editor benefits from it.

### `std::time::SystemTime::now()` panics on `wasm32-unknown-unknown`
The single use is in `rand_seed()` for non-deterministic seed generation. Switched to `web_time::SystemTime` only on `cfg(target_arch = "wasm32")`; native builds continue to use `std::time` exactly as before, and `web-time` is not pulled into native builds.

### WebGPU rejects writable storage bindings that alias the same buffer range
The compute bind group bound a single fallback buffer to both `dst_emission_buffer` and `src_emission_buffer` whenever a particle system had no sub-emitter configured. Native backends (Vulkan/Metal/DX12) tolerate this since the shader never reads or writes either buffer in that case, but WebGPU's static validator rejects it — which produced the "entire screen goes black" symptom (the validation error cascaded into invalid command buffers). Fixed by giving dst and src independent fallback buffers; left a comment at the allocation site so a future cleanup doesn't merge them back.

## Test plan

- [x] `cargo check -p bevy_sprinkles` (native) — clean
- [x] `cargo check -p bevy_sprinkles --target wasm32-unknown-unknown` — clean
- [x] `cargo check -p bevy_sprinkles_editor` (native) — clean, `file_watcher` still active
- [x] Manual: built for wasm + WebGPU and confirmed particles render in the browser without the previous WGPU validation errors